### PR TITLE
add `children` to propTypes

### DIFF
--- a/src/Carousel.jsx
+++ b/src/Carousel.jsx
@@ -79,6 +79,7 @@ Carousel.defaultProps = {
 // http://facebook.github.io/react/docs/reusable-components.html
 Carousel.propTypes = {
   centerDots: React.PropTypes.bool,
+  children: React.PropTypes.node,
 };
 
 Carousel.displayName = 'Carousel';


### PR DESCRIPTION
Since this component contains children, the`children` props should be specified.

Complete this props give automatic scripts the ability to detect whether the component is self-closing or not.